### PR TITLE
Prevent adding .map when asset already has an extension

### DIFF
--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -49,11 +49,14 @@ class BugsnagSourceMapPlugin {
     async.each(
       assets,
       (asset, callback) => {
-        let compiledAsset = asset.filter(s => s.slice(-3) === '.js')[0];
+        const compiledAsset = asset.filter(s => s.slice(-3) === '.js')[0];
+
+        let mapAsset = compiledAsset;
         if (compiledAsset.slice(-3) === '.js') {
-          compiledAsset = compiledAsset.slice(0, -3)
+          mapAsset = compiledAsset.slice(0, -3)
         }
-        const mapAsset = asset[asset.indexOf(`${compiledAsset}.map`)];
+        mapAsset = asset[asset.indexOf(`${mapAsset}.map`)];
+
         this.uploadSourceMap(compiledAsset, mapAsset, compilation);
         callback();
       },

--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -49,7 +49,10 @@ class BugsnagSourceMapPlugin {
     async.each(
       assets,
       (asset, callback) => {
-        const compiledAsset = asset.filter(s => s.slice(-3) === '.js')[0];
+        let compiledAsset = asset.filter(s => s.slice(-3) === '.js')[0];
+        if (compiledAsset.slice(-3) === '.js') {
+          compiledAsset = compiledAsset.slice(0, -3)
+        }
         const mapAsset = asset[asset.indexOf(`${compiledAsset}.map`)];
         this.uploadSourceMap(compiledAsset, mapAsset, compilation);
         callback();


### PR DESCRIPTION
Hi @bakunyo, 

A small PR for you. It seems the filenames for my assets are returning with the .js extensions and not for you. I've added a fix to handle both cases. 

Otherwise, it would concatenate the filename with .map (<filename>.js.map) and not find the asset down the path.

Would be great if you could look at this shortly since I hope to reference your master branch instead of the fork.

Thanks!