### PR TITLE
Fix Deprecation Warning on Node 8+

### DIFF
--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -94,7 +94,7 @@ class BugsnagSourceMapPlugin {
       }
 
       if (this.removeSourceMap) {
-        fs.unlink(sourceMapPath);
+        fs.unlinkSync(sourceMapPath);
       }
     });
   }


### PR DESCRIPTION
On Node 8+, calling asynchronous `fs` method without callback(2nd argument) is deprecated.

> Note: Omitting the callback function on asynchronous fs functions is deprecated and may result in an error being thrown in the future.
https://nodejs.org/api/fs.html#fs_file_system

In this plugin, the line below produces Deprecation Warnings(using `fs.unlink` without callback).
https://github.com/bakunyo/bugsnag-sourcemap-webpack-plugin/blob/master/src/BugsnagSourceMapPlugin.js#L97

![log](https://user-images.githubusercontent.com/1718007/33001835-aa15c91c-cdf3-11e7-8ccf-e7d322c0345c.PNG)

This PR introduces `fs.unlinkSync` instead of `fs.unlink` and fixes the problem.

## Test

- [x] `npm run test`