### PR TITLE
Update superagent dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "async": "^2.1.4",
-    "superagent": "^3.3.1"
+    "superagent": "^3.8.2"
   }
 }


### PR DESCRIPTION
`superagent` 3.3.1 has a dependency on a vulnerable version of the `mime` package. 

This update bumps the `superagent` dependency to a version which includes a patch to internally update their dependency on the `mime` package to a version without the vulnerability (v1.4.1).

More information about the `mime` package vulnerability: https://nodesecurity.io/advisories/535

All tests pass after making this update.